### PR TITLE
Fix calculation of row length in input-pnm.ci

### DIFF
--- a/input-pnm.ci
+++ b/input-pnm.ci
@@ -406,7 +406,7 @@ pnm_load_rawpbm (PNMScanner *scan,
 
   fd = pnmscanner_fd(scan);
   /****pts****/ /* rowlen = (unsigned int)ceil((double)(info->xres)/8.0);*/
-  rowlen = (info->xres >> 3) + (info->xres & 3 ? 1 : 0);
+  rowlen = (info->xres >> 3) + (info->xres & 7 ? 1 : 0);
   /* buf = (unsigned char *)malloc(rowlen*sizeof(unsigned char)); */
   XMALLOCT(buf, unsigned char*, rowlen*sizeof(unsigned char));
 


### PR DESCRIPTION
This fixes a bug where the row length calculation is wrong if xres is divisible by 4 but not by 8.  The fixed bug is a regression introduced in https://github.com/pts/sam2p/commit/beea3bd8dd05a731fddfa447ff0bad19fe32c973 .