### PR TITLE
Support an alternate make command.

### DIFF
--- a/configure
+++ b/configure
@@ -7518,9 +7518,9 @@ fi
 
 rm -f Makedep
 ac_n="${ac_n:-$ECHO_N}"
-echo $ac_n "running make Makedep.force""... $ac_c" 1>&6
-echo "configure:7504: running make Makedep.force" >&5
-if >&5 2>&5 make Makedep.force; then :
+echo $ac_n "running ${MAKE:-make} Makedep.force""... $ac_c" 1>&6
+echo "configure:7504: running ${MAKE:-make} Makedep.force" >&5
+if >&5 2>&5 ${MAKE:-make} Makedep.force; then :
   echo "$as_me:$LINENO: result: ok" >&5
 echo "${ECHO_T}ok" >&6
 

--- a/configure.in
+++ b/configure.in
@@ -216,7 +216,7 @@ AC_OUTPUT(Makehelp)
 
 dnl AC_PTS_RUN_OK([perl -x -S ./ccdep.pl $CXX], [], [AC_MSG_ERROR(cannot compute depends)])
 rm -f Makedep
-AC_PTS_RUN_OK([make Makedep.force], [], [AC_MSG_ERROR(cannot compute depends)])
+AC_PTS_RUN_OK([${MAKE:-make} Makedep.force], [], [AC_MSG_ERROR(cannot compute depends)])
 AC_PTS_OK
 echo "configure done. Now you should run: make; make install"
 


### PR DESCRIPTION
On many non-Linux platforms, the vendor-provided make command is not GNU make but either something more POSIXy or something derived from BSD, and GNU make will generally be available under a different name (usually 'gmake').  To support those platforms, allow the name of the make command to be overridden by an environment variable, with the standard 'make' as a fallback.