### PR TITLE
added -I:yes/-I:no option to control /Interpolate in EPS/PDF image dicts

### DIFF
--- a/README
+++ b/README
@@ -397,6 +397,9 @@ Options (case insensitive):
 -- -c:g3:2d                : [pts] equivalent to -c:fax:-2
 -- -c:jai                  : [pts] hint /Compression/JAI
 
+-- -I:yes -I:true -I:on    : [pts] hint /Interpolate/Yes (emit /Interpolate true in EPS/PDF image dict so viewers smooth scaled-up pixels)
+-- -I:no -I:false -I:off   : [pts] hint /Interpolate/No (emit /Interpolate false in EPS/PDF image dict)
+
 -- -m:dpi:(dimen)      : set /ImageDPI to `dimen'
 -- -m:(dimen) \        : set all margins (/TopMargin,/BottomMargin, /LeftMargin, /RightMargin) to `dimen'
    -m:all:(dimen) \    :                  /LeftMargin, /RightMargin) to `dimen'

--- a/bts.ttt
+++ b/bts.ttt
@@ -21,7 +21,7 @@
 save`s 9 dict begin
 {/T currentfile`T def`1setcolorspace
 /F T`F def
-<</ImageType 1/Width `w/Height `h/BitsPerComponent
+<<`n/ImageType 1/Width `w/Height `h/BitsPerComponent
 `b/ImageMatrix[1 0 0 -1 0 `h]/Decode
 [`D]/DataSource F>> image
 `t}
@@ -132,7 +132,7 @@ end restore showpage
 [ (1 0 obj\n<</Type/Catalog/Pages 2 0 R>>\nendobj\n) ] %7.0
 [ (4 0 obj\n<</Length ) ] %8.0
 -11 %9
-(/Interpolate false/Type/XObject/Name/S/Subtype/Image/ColorSpace`1/Width
+(`N/Type/XObject/Name/S/Subtype/Image/ColorSpace`1/Width
 `w/Height `h/BitsPerComponent `b`F>>stream\n) %10
 [ (`S) ] %11
 (\nendstream\nendobj\n) %12
@@ -167,7 +167,7 @@ end restore showpage
 [ (1 0 obj\n<</Type/Catalog/Pages 2 0 R>>\nendobj\n) ] %7.0
 [ (4 0 obj\n<</Length ) ] %8.0
 -11 %9
-(/Interpolate false/Type/XObject/Name/S/Subtype/Image/ImageMask
+(`N/Type/XObject/Name/S/Subtype/Image/ImageMask
 true/BitsPerComponent 1/Width `w/Height `h`F>>stream\n) %10
 [ (`S) ] %11
 (\nendstream\nendobj\n) %12
@@ -237,7 +237,7 @@ EI\nQ\n) ] %5.0
 [ (1 0 obj\n<</Type/Catalog/Pages 2 0 R>>\nendobj\n) ] %7.0
 [ (4 0 obj\n<</Length ) ] %8.0
 -11 %9
-(/Interpolate false/Type/XObject/Name/S/Subtype/Image/ImageMask
+(`N/Type/XObject/Name/S/Subtype/Image/ImageMask
 true/BitsPerComponent 1/Width `w/Height `h`F>>stream\n) %10
 [ (`S) ] %11
 (\nendstream\nendobj\n) %12
@@ -302,7 +302,7 @@ EI\nQ\n) ] %5.0
 [ (3 0 obj\n<</Length ) ] %2
 -5 %3: length of chunk 5
 (>>\nstream\n) %4
-[ (q`s\n`w 0 0 `h 0 0 cm\nBI/Interpolate false/W `w/H `h/CS`1/BPC `b`F ID
+[ (q`s\n`w 0 0 `h 0 0 cm\nBI`N/W `w/H `h/CS`1/BPC `b`F ID
 `S
 EI\nQ\n) ] %5.0
 (endstream\nendobj\n) %6
@@ -337,7 +337,7 @@ EI\nQ\n) ] %5.0
 %[ (3 0 obj\n<</Length ) ] %2
 %-5 %3: length of chunk 5
 %(>>\nstream\n) %4
-%[ (q`s\n`w 0 0 `h 0 0 cm\nBI/Interpolate false/W `w/H `h/CS`1/BPC `b`F ID
+%[ (q`s\n`w 0 0 `h 0 0 cm\nBI`N/W `w/H `h/CS`1/BPC `b`F ID
 %`S
 %EI\nQ\n) ] %5.0
 %(endstream\nendobj\n) %6
@@ -366,7 +366,7 @@ save`s 2 dict begin
 {/Device`d setcolorspace
 /T currentfile`T def
 /F T/DCTDecode filter def
-<</ImageType 1/Width `w/Height `h/BitsPerComponent
+<<`n/ImageType 1/Width `w/Height `h/BitsPerComponent
 `b/ImageMatrix[1 0 0 -1 0 `h]/Decode
 [`D]/DataSource F>> image`t}
 %%BeginData:;
@@ -389,7 +389,7 @@ end restore showpage
 [ (1 0 obj\n<</Type/Catalog/Pages 2 0 R>>\nendobj\n) ] %7.0
 [ (4 0 obj\n<</Length ) ] %8.0
 -11 %9
-(/Type/XObject/Name/S/Subtype/Image/ColorSpace/Device`d/Width
+(`n/Type/XObject/Name/S/Subtype/Image/ColorSpace/Device`d/Width
 `w/Height `h/BitsPerComponent `b`F>>stream\n) %10
 [ (`S) ] %11
 (\nendstream\nendobj\n) %12
@@ -421,7 +421,7 @@ end restore showpage
 [ (3 0 obj\n<</Length ) ] %2
 -5 %3: length of chunk 5
 (>>\nstream\n) %4
-[ (q`s\n`w 0 0 `h 0 0 cm\nBI/W `w/H `h/CS/Device`d/BPC `b`F ID
+[ (q`s\n`w 0 0 `h 0 0 cm\nBI`n/W `w/H `h/CS/Device`d/BPC `b`F ID
 `S
 EI\nQ\n) ] %5.0
 (endstream\nendobj\n) %6
@@ -967,7 +967,7 @@ c - ;/Ex c E O exit}{2 y c y O ? 2 y c ? c - ;}i d u 128 le{L c 0 c 1 + ; u ? 1
 O 0 c ;}i}loop B{12 * H c 12 ; 3 y p O 12 +}forall O O R}false 3 colorimage
 d O d O}bind exec}{
 [/Indexed/DeviceRGB `# 1 - T `p " readstring O]setcolorspace
-/F T/RunLengthDecode filter def<</ImageType 1/Width `w/Height `h
+/F T/RunLengthDecode filter def<<`n/ImageType 1/Width `w/Height `h
 /BitsPerComponent `b/ImageMatrix[1 0 0 -1 0 `h]/Decode[`D]/DataSource F>>
 image F closefile T closefile
 }ifelse}
@@ -1007,7 +1007,7 @@ A c S O}{L c d c 257 c - 3 y 1 - -1 0{3 y c put O}for O O c
 O 0 c ;}i}loop B{12 * H c 12 ; 3 y p O 12 +}forall O O R}false 3 colorimage
 d O A read O O}bind exec}{
 [/Indexed/DeviceRGB `# 1 - T `p " readstring O]setcolorspace
-/F T/RunLengthDecode filter def<</ImageType 1/Width `w/Height `h
+/F T/RunLengthDecode filter def<<`n/ImageType 1/Width `w/Height `h
 /BitsPerComponent `b/ImageMatrix[1 0 0 -1 0 `h]/Decode[`D]/DataSource F>>
 image F closefile T closefile
 }ifelse}
@@ -1046,7 +1046,7 @@ c - ;/Ex c E O exit}{2 y c y O ? 2 y c ? c - ;}i A read O u 128 le{L c 0 c 1 +
 O 0 c ;}i}loop B{12 * H c 12 ; 3 y p O 12 +}forall O O R}false 3 colorimage
 A read O O}bind exec}{
 [/Indexed/DeviceRGB `# 1 - A `p " S O]setcolorspace
-/F A/RunLengthDecode filter def<</ImageType 1/Width `w/Height `h
+/F A/RunLengthDecode filter def<<`n/ImageType 1/Width `w/Height `h
 /BitsPerComponent `b/ImageMatrix[1 0 0 -1 0 `h]/Decode[`D]/DataSource F>>
 image F closefile}ifelse}
 %%BeginData:;
@@ -1086,7 +1086,7 @@ u -2 b 3 and B c 3 * 3 ; H c R c p/R R 3 + E
 {12 * H c 12 ; 3 y p O 12 +}forall O O R}false 3 colorimage
 d O}bind exec}{
 [/Indexed/DeviceRGB `# 1 - T `p " readstring O]setcolorspace
-<</ImageType 1/Width `w/Height `h/BitsPerComponent `b/ImageMatrix[1 0 0 -1 0
+<<`n/ImageType 1/Width `w/Height `h/BitsPerComponent `b/ImageMatrix[1 0 0 -1 0
 `h]/Decode[`D]/DataSource T>>image T closefile}ifelse}
 %%BeginData:;
 exec
@@ -1121,7 +1121,7 @@ u -2 b 3 and B c 3 * 3 ; H c R c p/R R 3 + E
 {12 * H c 12 ; 3 y p O 12 +}forall O O R}false 3 colorimage
 A read O O}bind exec}{
 [/Indexed/DeviceRGB `# 1 - T `p " readstring O]setcolorspace
-<</ImageType 1/Width `w/Height `h/BitsPerComponent `b/ImageMatrix[1 0 0 -1 0
+<<`n/ImageType 1/Width `w/Height `h/BitsPerComponent `b/ImageMatrix[1 0 0 -1 0
 `h]/Decode[`D]/DataSource T>>image T closefile}ifelse}
 %%BeginData:;
 exec
@@ -1161,7 +1161,7 @@ c - ;/Ex c E O exit}{2 y c y O ? 2 y c ? c - ;}i d u 128 le{L c 0 c 1 + ; u ? 1
 O 0 c ;}i}loop B{6 * H c 6 ; 3 y p O 6 +}forall O O R}false 3 colorimage
 d O d O}bind exec}{
 [/Indexed/DeviceRGB `# 1 - T `p " readstring O]setcolorspace
-/F T/RunLengthDecode filter def<</ImageType 1/Width `w/Height `h
+/F T/RunLengthDecode filter def<<`n/ImageType 1/Width `w/Height `h
 /BitsPerComponent `b/ImageMatrix[1 0 0 -1 0 `h]/Decode[`D]/DataSource F>>
 image F closefile T closefile
 }ifelse}
@@ -1199,7 +1199,7 @@ A c S O}{L c d c 257 c - 3 y 1 - -1 0{3 y c put O}for O O c
 O 0 c ;}i}loop B{6 * H c 6 ; 3 y p O 6 +}forall O O R}false 3 colorimage
 d O A read O O}bind exec}{
 [/Indexed/DeviceRGB `# 1 - T `p " readstring O]setcolorspace
-/F T/RunLengthDecode filter def<</ImageType 1/Width `w/Height `h
+/F T/RunLengthDecode filter def<<`n/ImageType 1/Width `w/Height `h
 /BitsPerComponent `b/ImageMatrix[1 0 0 -1 0 `h]/Decode[`D]/DataSource F>>
 image F closefile T closefile
 }ifelse}
@@ -1235,7 +1235,7 @@ c - ;/Ex c E O exit}{2 y c y O ? 2 y c ? c - ;}i A read O u 128 le{L c 0 c 1 +
 O 0 c ;}i}loop B{6 * H c 6 ; 3 y p O 6 +}forall O O R}false 3 colorimage
 A read O O}bind exec}{
 O[/Indexed/DeviceRGB `# 1 - A `p " S O]setcolorspace
-/F A/RunLengthDecode filter def<</ImageType 1/Width `w/Height `h
+/F A/RunLengthDecode filter def<<`n/ImageType 1/Width `w/Height `h
 /BitsPerComponent `b/ImageMatrix[1 0 0 -1 0 `h]/Decode[`D]/DataSource F>>
 image F closefile}ifelse}
 %%BeginData:;
@@ -1273,7 +1273,7 @@ eq{22}{S 8 -}i}i E}i}E
 {6 * H c 6 ; 3 y p O 6 +}forall O O R}false 3 colorimage
 d O}bind exec}{
 [/Indexed/DeviceRGB `# 1 - T `p " readstring O]setcolorspace
-<</ImageType 1/Width `w/Height `h/BitsPerComponent `b/ImageMatrix[1 0 0 -1 0
+<<`n/ImageType 1/Width `w/Height `h/BitsPerComponent `b/ImageMatrix[1 0 0 -1 0
 `h]/Decode[`D]/DataSource T>>image T closefile}ifelse}
 %%BeginData:;
 exec
@@ -1306,7 +1306,7 @@ A 48 " u/B c E 0 `p ; S O O/H 1536 " E/R 0 E
 {6 * H c 6 ; 3 y p O 6 +}forall O O R}false 3 colorimage
 A read O O}bind exec}{
 [/Indexed/DeviceRGB `# 1 - T `p " readstring O]setcolorspace
-<</ImageType 1/Width `w/Height `h/BitsPerComponent `b/ImageMatrix[1 0 0 -1 0
+<<`n/ImageType 1/Width `w/Height `h/BitsPerComponent `b/ImageMatrix[1 0 0 -1 0
 `h]/Decode[`D]/DataSource T>>image T closefile}ifelse}
 %%BeginData:;
 exec
@@ -1345,7 +1345,7 @@ c - ;/Ex c E O exit}{2 y c y O ? 2 y c ? c - ;}i d u 128 le{L c 0 c 1 + ; u ? 1
 O 0 c ;}i}loop B{3 * H c 3 ; 3 y p O 3 +}forall O O R}false 3 colorimage
 d O d O}bind exec}{
 [/Indexed/DeviceRGB `# 1 - T `p " readstring O]setcolorspace
-/F T/RunLengthDecode filter def<</ImageType 1/Width `w/Height `h
+/F T/RunLengthDecode filter def<<`n/ImageType 1/Width `w/Height `h
 /BitsPerComponent `b/ImageMatrix[1 0 0 -1 0 `h]/Decode[`D]/DataSource F>>
 image F closefile T closefile
 }ifelse}
@@ -1380,7 +1380,7 @@ A c S O}{L c d c 257 c - 3 y 1 - -1 0{3 y c put O}for O O c
 O 0 c ;}i}loop B{3 * H c 3 ; 3 y p O 3 +}forall O O R}false 3 colorimage
 d O A read O O}bind exec}{
 [/Indexed/DeviceRGB `# 1 - T `p " readstring O]setcolorspace
-/F T/RunLengthDecode filter def<</ImageType 1/Width `w/Height `h
+/F T/RunLengthDecode filter def<<`n/ImageType 1/Width `w/Height `h
 /BitsPerComponent `b/ImageMatrix[1 0 0 -1 0 `h]/Decode[`D]/DataSource F>>
 image F closefile T closefile
 }ifelse}
@@ -1413,7 +1413,7 @@ c - ;/Ex c E O exit}{2 y c y O ? 2 y c ? c - ;}i A read O u 128 le{L c 0 c 1 +
 O 0 c ;}i}loop B{3 * H c 3 ; 3 y p O 3 +}forall O O R}false 3 colorimage
 A read O O}bind exec}{
 O[/Indexed/DeviceRGB `# 1 - A `p " S O]setcolorspace
-/F A/RunLengthDecode filter def<</ImageType 1/Width `w/Height `h
+/F A/RunLengthDecode filter def<<`n/ImageType 1/Width `w/Height `h
 /BitsPerComponent `b/ImageMatrix[1 0 0 -1 0 `h]/Decode[`D]/DataSource F>>
 image F closefile}ifelse}
 %%BeginData:;
@@ -1449,7 +1449,7 @@ eq{22}{S 8 -}i}i E}i}E
 {3 * H c 3 ; 3 y p O 3 +}forall O O R}false 3 colorimage
 d O}bind exec}{
 [/Indexed/DeviceRGB `# 1 - T `p " readstring O]setcolorspace
-<</ImageType 1/Width `w/Height `h/BitsPerComponent `b/ImageMatrix[1 0 0 -1 0
+<<`n/ImageType 1/Width `w/Height `h/BitsPerComponent `b/ImageMatrix[1 0 0 -1 0
 `h]/Decode[`D]/DataSource T>>image T closefile}ifelse}
 %%BeginData:;
 exec
@@ -1479,7 +1479,7 @@ A 768 " u/H c E 0 `p ; d O O/B `w " E/R `w 3 *
 {3 * H c 3 ; 3 y p O 3 +}forall O O R}false 3 colorimage
 A read O O}bind exec}{
 [/Indexed/DeviceRGB `# 1 - T `p " readstring O]setcolorspace
-<</ImageType 1/Width `w/Height `h/BitsPerComponent `b/ImageMatrix[1 0 0 -1 0
+<<`n/ImageType 1/Width `w/Height `h/BitsPerComponent `b/ImageMatrix[1 0 0 -1 0
 `h]/Decode[`D]/DataSource T>>image T closefile}ifelse}
 %%BeginData:;
 exec
@@ -1512,7 +1512,7 @@ u -2 b 3 and B c 3 * 3 ; H c R c p/R R 3 + E
 `w `h 8[1 0 0 -1 0 `h]{B3 0 A B S O
 {12 * H c 12 ; 3 y p O 12 +}forall O O R}false 3 colorimage}bind exec}{
 O[/Indexed/DeviceRGB `# 1 - A `p " S O]setcolorspace
-<</ImageType 1/Width `w/Height `h/BitsPerComponent `b/ImageMatrix[1 0 0 -1 0
+<<`n/ImageType 1/Width `w/Height `h/BitsPerComponent `b/ImageMatrix[1 0 0 -1 0
 `h]/Decode[`D]/DataSource A>>image}ifelse}
 %%BeginData:;
 exec
@@ -1543,7 +1543,7 @@ A 48 " u/B c E 0 `p ; S O O/H 1536 " E/R 0 E
 `w `h 8[1 0 0 -1 0 `h]{B3 0 A B S O
 {6 * H c 6 ; 3 y p O 6 +}forall O O R}false 3 colorimage}bind exec}{
 O[/Indexed/DeviceRGB `# 1 - A `p " S O]setcolorspace
-<</ImageType 1/Width `w/Height `h/BitsPerComponent `b/ImageMatrix[1 0 0 -1 0
+<<`n/ImageType 1/Width `w/Height `h/BitsPerComponent `b/ImageMatrix[1 0 0 -1 0
 `h]/Decode[`D]/DataSource A>>image}ifelse}
 %%BeginData:;
 exec
@@ -1572,7 +1572,7 @@ A 768 " u/H c E 0 `p ; d O O/B `w " E/R `w 3 *
 " E `w `h 8[1 0 0 -1 0 `h]{R 0 A B d O
 {3 * H c 3 ; 3 y p O 3 +}forall O O R}false 3 colorimage}bind exec}{
 O[/Indexed/DeviceRGB `# 1 - A `p " d O]setcolorspace
-<</ImageType 1/Width `w/Height `h/BitsPerComponent `b/ImageMatrix[1 0 0 -1 0
+<<`n/ImageType 1/Width `w/Height `h/BitsPerComponent `b/ImageMatrix[1 0 0 -1 0
 `h]/Decode[`D]/DataSource A>>image}ifelse}
 %%BeginData:;
 exec

--- a/rule.cpp
+++ b/rule.cpp
@@ -86,7 +86,7 @@ bool Rule::Cache::isZIPOK() const {
 
 static MiniPS::Dict *y_FileFormat=(MiniPS::Dict*)NULLP,
   *y_SampleFormat, *y_TransferEncoding,
-  *y_Compression, *y_Scale;
+  *y_Compression, *y_Scale, *y_Interpolate;
 static class ValueDeleter {
  public:
   ~ValueDeleter() {
@@ -95,6 +95,7 @@ static class ValueDeleter {
     MiniPS::delete0((MiniPS::VALUE)y_TransferEncoding);
     MiniPS::delete0((MiniPS::VALUE)y_Compression);
     MiniPS::delete0((MiniPS::VALUE)y_Scale);
+    MiniPS::delete0((MiniPS::VALUE)y_Interpolate);
   }
 } value_deleter;
 
@@ -196,6 +197,16 @@ static void init_dicts() {
   y->put("/None",    MiniPS::Qinteger(Rule::CacheHints::SC_None));
   y->put("/OK",      MiniPS::Qinteger(Rule::CacheHints::SC_OK));
   y->put("/RotateOK",MiniPS::Qinteger(Rule::CacheHints::SC_RotateOK));
+
+  y=y_Interpolate=new MiniPS::Dict();
+  y->put("/ ",      MiniPS::Qinteger(Rule::Cache::IP_default)); /* default */
+  y->put("/Default",MiniPS::Qinteger(Rule::Cache::IP_default));
+  y->put("/No",     MiniPS::Qinteger(Rule::Cache::IP_No));
+  y->put("/false",  MiniPS::Qinteger(Rule::Cache::IP_No));
+  y->put("/Off",    MiniPS::Qinteger(Rule::Cache::IP_No));
+  y->put("/Yes",    MiniPS::Qinteger(Rule::Cache::IP_Yes));
+  y->put("/true",   MiniPS::Qinteger(Rule::Cache::IP_Yes));
+  y->put("/On",     MiniPS::Qinteger(Rule::Cache::IP_Yes));
 }
 
 Image::sf_t Rule::Cache::parseSampleFormat(char const*s, slen_t slen) {
@@ -356,7 +367,7 @@ void Rule::OutputRule::fromDict(MiniPS::VALUE dict_) {
   #endif
   MiniPS::VALUE dummy;  (void)dummy;
   MiniPS::VALUE FileFormat, SampleFormat, WarningOK, TransferEncoding,
-    Compression, Predictor, Transparent;
+    Compression, Predictor, Transparent, Interpolate;
   MiniPS::VALUE PredictorColumns, PredictorColors, PredictorBPC, Effort, K,
     RecordSize, Quality, ColorTransform, TransferCPL,
     EncoderRows, EncoderColumns, EncoderBPL, EncoderColors, DCT, Scale;
@@ -368,6 +379,7 @@ void Rule::OutputRule::fromDict(MiniPS::VALUE dict_) {
     "TransferEncoding",MiniPS::S_SENUM,   y_TransferEncoding, &TransferEncoding,
     "Compression",     MiniPS::S_SENUM,   y_Compression,      &Compression,
     "Predictor",       MiniPS::S_FUNC,    better_predictor,   &Predictor,
+    "Interpolate",     MiniPS::S_SENUM,   y_Interpolate,      &Interpolate,
     "Transparent",     MiniPS::S_RGBSTR,  MiniPS::Qnull,      &Transparent, /* force an RGB color transparent */
     "Hints",           MiniPS::T_DICT,    MiniPS::Qnull,      &dictHints,
     NULLP
@@ -379,6 +391,7 @@ void Rule::OutputRule::fromDict(MiniPS::VALUE dict_) {
   cache.TransferEncoding=(Rule::Cache::te_t)MiniPS::int2ii(TransferEncoding);
   cache.Compression=(Rule::Cache::co_t)MiniPS::int2ii(Compression);
   cache.Predictor=(Rule::Cache::pr_t)MiniPS::int2ii(Predictor);
+  cache.Interpolate=(Rule::Cache::ip_t)MiniPS::int2ii(Interpolate);
   cache.Transparent=0x1000000UL; /* No extra transparency */
   if (Transparent!=MiniPS::Qnull) {
     unsigned char const*p=(unsigned char const*)(MiniPS::RSTRING(Transparent)->begin_());
@@ -835,6 +848,20 @@ void Rule::writeTTE(
       out << (or_->cache.isGray() ? "image"
             : or_->cache.SampleFormat==Image::SF_Mask || or_->cache.SampleFormat==Image::SF_Indexed1 ? "imagemask"
             : "false 3 colorimage");
+      break;
+     case 'N': /* /Interpolate image-dict key; defaults to /Interpolate false */
+      switch (or_->cache.Interpolate) {
+       case Rule::Cache::IP_Yes:     out << "/Interpolate true";  break;
+       case Rule::Cache::IP_No:      out << "/Interpolate false"; break;
+       case Rule::Cache::IP_default: out << "/Interpolate false"; break;
+      }
+      break;
+     case 'n': /* /Interpolate image-dict key; defaults to omitted */
+      switch (or_->cache.Interpolate) {
+       case Rule::Cache::IP_Yes:     out << "/Interpolate true";  break;
+       case Rule::Cache::IP_No:      out << "/Interpolate false"; break;
+       case Rule::Cache::IP_default: /* nothing */                break;
+      }
       break;
      case 'I': /* PS warning for usage of colorimage operator */
        // if (!or_->cache.isGray()) out << "% PSLC required\n";

--- a/rule.hpp
+++ b/rule.hpp
@@ -94,6 +94,13 @@ class Rule { public:
     END_STATIC_ENUM()
     pr_t Predictor;
 
+    BEGIN_STATIC_ENUM(unsigned char,ip_t)
+      IP_default=0, /* emit nothing, or /Interpolate false in templates that historically hard-coded it */
+      IP_No=1,      /* force /Interpolate false */
+      IP_Yes=2      /* force /Interpolate true */
+    END_STATIC_ENUM()
+    ip_t Interpolate;
+
     Image::Sampled::rgb_t Transparent;
     
     bool isOneBit() const;

--- a/sam2p.1
+++ b/sam2p.1
@@ -134,6 +134,37 @@ set output EPS or PDF to resolution \fIres\fP dpi
 select compression type (support depends on output format)
 .sp 1
 .TP
+.B \-I:yes, \-I:no
+set the
+.B /Interpolate
+flag in the image dictionary of EPS (PSL2/PSL3) and PDF output.
+.B yes
+(also
+.BR true ,
+.BR on )
+emits
+.B /Interpolate true
+so PostScript/PDF viewers smooth pixels when the image is scaled up.
+.B no
+(also
+.BR false ,
+.BR off )
+emits
+.BR "/Interpolate false" .
+Omitting
+.B \-I
+leaves the key absent from EPS dicts and from the JPEG-passthrough PDF dict,
+and emitted as
+.B /Interpolate false
+elsewhere in PDF.
+PSL1 output cannot carry the flag.
+The same key is accepted inside a job-file Profile as
+.BR "/Interpolate /Yes" ,
+.BR /No ,
+or
+.BR /Default .
+.sp 1
+.TP
 .B \-j:quiet
 print only error and fatal error messages, suppress warnings, notices etc.
 Must be put at the beginning of the command line to suppress initial banners, too.

--- a/sam2p_main.cpp
+++ b/sam2p_main.cpp
@@ -175,7 +175,8 @@ static const unsigned
   OPT_Scale=0x101,
   OPT_Margins=0x112,
   OPT_Transparent=0x122,
-  OPT_TmpRemove=0x132;
+  OPT_TmpRemove=0x132,
+  OPT_Interpolate=0x142;
 
 /** @param s an option (lower/upper case intact), without leading `-'s
  * @param slen length of option 
@@ -193,6 +194,7 @@ static unsigned sam2p_optval(char const* s, slen_t slen) {
      case 't': return OPT_TransferEncoding;
      case 'f': return OPT_TransferEncodingF;
      case 'c': return OPT_Compression;
+     case 'I': return OPT_Interpolate;
      // case 'a': return OPT_Asis; /* disabled, automatic! */
      case '1': return OPT_PSL1;
      case '2': return OPT_PSL2;
@@ -213,6 +215,7 @@ static unsigned sam2p_optval(char const* s, slen_t slen) {
     if (0==strcmp(buf, "loadhints")) return OPT_LoadHints;
     if (0==strcmp(buf, "tmpremove")) return OPT_TmpRemove;
     if (0==strcmp(buf, "transparent")) return OPT_Transparent;
+    if (0==strcmp(buf, "interpolate")) return OPT_Interpolate;
     if (0==strcmp(buf, "hints")) return OPT_Hints;
     if (0==strcmp(buf, "ps")
      || 0==strcmp(buf, "eps")) return OPT_PS;
@@ -300,6 +303,7 @@ static bool one_liner(SimBuffer::B &jobss, char const *const* a) {
              *LowerMargin=(char const*)NULLP, *ImageDPI=(char const*)NULLP;
   bool negLowerMargin=false;
   Rule::CacheHints::sc_t Scale=Rule::CacheHints::SC_default;
+  Rule::Cache::ip_t Interpolate=Rule::Cache::IP_default;
   #define APPEND_sf(val) do { if (sfx[val]==0) { sfx[val]=1; sft[sflen++]=val; } } while (0)
   Image::sf_t sft[Image::SF_max+1];       char sfx[Image::SF_max+1]; memset(sfx, 0, sizeof(sfx)); unsigned sflen=0;
   #define APPEND_co(val) do { if (cox[val]==0) { cox[val]=1; cot[colen++]=val; } } while (0)
@@ -404,6 +408,15 @@ static bool one_liner(SimBuffer::B &jobss, char const *const* a) {
         else Scale=(Rule::CacheHints::sc_t)(GenBuffer::parseBool(param, paramlen) ? 0+Rule::CacheHints::SC_OK : 0+Rule::CacheHints::SC_None);
         /* ^^^ Imp: better error report */
         /* ^^^ +0: pacify g++-3.1 */
+        break;
+       case OPT_Interpolate:
+             if (0==GenBuffer::nocase_strcmp(param, "yes")
+              || 0==GenBuffer::nocase_strcmp(param, "true")
+              || 0==GenBuffer::nocase_strcmp(param, "on"))   Interpolate=Rule::Cache::IP_Yes;
+        else if (0==GenBuffer::nocase_strcmp(param, "no")
+              || 0==GenBuffer::nocase_strcmp(param, "false")
+              || 0==GenBuffer::nocase_strcmp(param, "off"))  Interpolate=Rule::Cache::IP_No;
+        else goto inv_par;
         break;
        case OPT_TransferEncoding:
              if (0==GenBuffer::nocase_strcmp(param, "bin"))  TransferEncoding=Rule::Cache::TE_Binary;
@@ -896,6 +909,9 @@ static bool one_liner(SimBuffer::B &jobss, char const *const* a) {
                   prc > 1 ? Rule::Cache::PR_PNGAuto+0 /* 15 */ :
                   Predictor == Rule::Cache::PR_PNGAutoMaybe ? Rule::Cache::PR_None+0 : Predictor)
               << "\n  /Hints << " << Hints << " >>";
+        if (Interpolate!=Rule::Cache::IP_default) {
+          jobss << "\n  /Interpolate /" << (Interpolate==Rule::Cache::IP_Yes ? "Yes" : "No");
+        }
         // jobss << "  /Transparent (\377\377\377)\n";
         if (Transparent!=NULL) {
           jobss << "\n  /Transparent ";


### PR DESCRIPTION
This new option allows you to control whether the EPS or PDF viewer/printer should interpolate between pixels at higher magnification (good for photos and other inherently smooth images), or should show square pixels (good for traditional low-res desktop screenshots and other inherently pixelated images, the default).